### PR TITLE
Filter out archived headings from agenda

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -43,6 +43,7 @@
 (declare-function org-agenda-format-item "ext:org-agenda.el")
 (declare-function org-compile-prefix-format "ext:org-agenda.el")
 (declare-function org-entry-is-done-p "ext:org.el")
+(declare-function org-in-archived-heading-p "ext:org.el")
 (declare-function org-get-category "ext:org.el")
 (declare-function org-get-deadline-time "ext:org.el")
 (declare-function org-get-heading "ext:org.el")
@@ -1101,6 +1102,7 @@ if returns a point."
         (deadline-time (org-get-deadline-time (point)))
         (due-date (dashboard-due-date-for-agenda)))
     (unless (and (not (org-entry-is-done-p))
+                 (not (org-in-archived-heading-p))
                  (or (and schedule-time
                           (org-time-less-p schedule-time due-date))
                      (and deadline-time
@@ -1112,7 +1114,8 @@ if returns a point."
 An entry is included if this function returns nil and excluded
 if returns a point."
   (unless (and (org-entry-is-todo-p)
-               (not (org-entry-is-done-p)))
+               (not (org-entry-is-done-p))
+               (not (org-in-archived-heading-p)))
     (point)))
 
 (defun dashboard-no-filter-agenda ()


### PR DESCRIPTION
This change removes archived items, i.e. headings under a tree with the ARCHIVE tag, from the agenda shown on the dashboard. Tested locally on my Emacs setup.